### PR TITLE
Fix release URL to be commit-specific and fix version number for autoupdate to work properly

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "AutoBD"
 description.en = "Application for creating a comic strip"
 description.fr = "Application permettant de réaliser une bande dessinée"
 
-version = "1.0~ynh5"
+version = "2025.11.05~ynh1"
 
 maintainers = ["eric_G"]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -47,8 +47,8 @@ ram.runtime = "150M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://forge.apps.education.fr/educajou/autobd/-/archive/main/autobd-main.tar.gz"
-    sha256 = "fe624bbbf89225fcdc27f2695d494f54afda7beeabc6b24198688d493d86156c"
+    url = "https://forge.apps.education.fr/educajou/autobd/-/archive/c2a631f74cd851cfd0f84d9a5e680ffa7d6a2f4b/autobd-main-c2a631f74cd851cfd0f84d9a5e680ffa7d6a2f4b.tar.gz"
+    sha256 = "07bdafdf59ba41283929aa60aaf3b2459ea4779b1c8d669a3dceaa15660be9df"
 
     autoupdate.strategy = "latest_gitlab_commit"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -48,7 +48,7 @@ ram.runtime = "150M"
 
     [resources.sources.main]
     url = "https://forge.apps.education.fr/educajou/autobd/-/archive/c2a631f74cd851cfd0f84d9a5e680ffa7d6a2f4b/autobd-main-c2a631f74cd851cfd0f84d9a5e680ffa7d6a2f4b.tar.gz"
-    sha256 = "07bdafdf59ba41283929aa60aaf3b2459ea4779b1c8d669a3dceaa15660be9df"
+    sha256 = "cc481c241297c7059855fe67a07e64afcf4a04b667675c6a0a3e243782dd9ef5"
 
     autoupdate.strategy = "latest_gitlab_commit"
 


### PR DESCRIPTION
With the generic "latest release" URL, for each next upstream commit, the corresponding sha256 will not match anymore thus making the app impossible to install.

Also `latest_gitlab_commit` strategy expects a YYYY.MM.DD version number so that autoupdate script works as expected.